### PR TITLE
docs: factual README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,40 @@
-# specs
-Repository for keeping specs and RFC for subsquid
+# SQD specs and RFCs
+
+Specifications, RFCs, and research notes for [SQD](https://sqd.dev). SQD is an open data platform for Web3, including the SQD Network (a decentralized data lake) and the SQD Portal data API. This repository holds design documents, not running code.
+
+## What is in here
+
+The repository is organized into three areas.
+
+### `network-rfc/`
+
+An RFC describing the architecture of the SQD Network: the desired state of the network and the processes that run within it. The overview is in [`network-rfc/README.md`](network-rfc/README.md), with individual documents covering:
+
+- Scheduling algorithm and assignment lifecycle
+- Data delivery and network communication
+- Node (worker and portal) registration
+- Compute units allocation
+- Sending queries, collecting query logs, and logs validation
+- Distributing rewards
+- Portal API and portal configuration
+
+The RFC also describes the network components it refers to: workers, portals (network gateways), bootnodes, the logs collector, the pings collector, the scheduler, and data storage. An Excalidraw source file (`network-rfc/sqd_network.excalidraw`) and diagram attachments are included.
+
+### `SLOs/`
+
+Service Level Indicator (SLI) and Service Level Objective (SLO) specifications. [`SLOs/hotblocks.md`](SLOs/hotblocks.md) defines the SLIs and SLOs for the HotBlocks real-time blockchain data service, including latency and availability targets and the metrics used to track them.
+
+### `sql-research/`
+
+Research notes, design documents, and meeting minutes related to SQL query engine work over SQD data, including DuckDB and Trino investigations. [`sql-research/0000-repos.md`](sql-research/0000-repos.md) lists the related prototype repositories. The `sql-research/papers/` directory holds reference papers (PDFs) cited by these notes.
+
+## Documentation
+
+For product documentation, see:
+
+- SQD docs: https://docs.sqd.dev
+- SQD Network docs: https://docs.sqd.dev/en/network
+
+## License
+
+GNU General Public License v3.0. See [`LICENSE`](LICENSE).


### PR DESCRIPTION
Expands the one-line stub README into a factual description of what this repository contains.

## What I confirmed (by reading the files)

- This is a documentation-only repo (no package.json / Cargo.toml / source build). Confirmed from the top-level listing: `README.md`, `LICENSE`, `.gitignore`, and three content directories.
- **`network-rfc/`** is an RFC on the SQD Network architecture. Confirmed from `network-rfc/README.md` (titled "SQD Network Architecture") and the 13 markdown files: scheduling algorithm, assignment lifecycle, data delivery, network communication, node registration, compute units allocation, sending queries, collecting query logs, logs validation, distributing rewards, portal API, portal config. Components (worker, portal/gateway, bootnode, logs collector, pings collector, scheduler, data storage) are described in that README. Also includes `sqd_network.excalidraw` and an `attachments/` dir.
- **`SLOs/hotblocks.md`** defines SLIs/SLOs for the HotBlocks real-time blockchain data service (latency and availability targets, tracking metrics). Confirmed from the file header and content.
- **`sql-research/`** holds research notes, design docs, and meeting minutes for SQL query engine work (DuckDB, Trino). Confirmed from `sql-research/0000-repos.md` (lists prototype repos: sql4sqd-prototype, duckdb-extension-prototype, trino-sqd), the dated note files, `minutes/`, and `papers/` (reference PDFs).
- **License**: GPL v3.0. Confirmed from `LICENSE` header.

## Style

- No marketing language, no em dashes, "onchain" form, no "ship" verb.
- Only states what is present in the repo; no invented features or chains.

## Links verified (HTTP 200 via curl -L)

- https://docs.sqd.dev
- https://docs.sqd.dev/en/network
- https://sqd.dev

All internal links point to files confirmed present in the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)